### PR TITLE
Exercisim support, fixes #2

### DIFF
--- a/dotfiles/profile.symlink
+++ b/dotfiles/profile.symlink
@@ -26,7 +26,7 @@ else
 fi
 
 # exercism
-export PATH="HOME/.exercism:$PATH"
+export PATH="$HOME/.exercism:$PATH"
 
 # rubygems
 PATH="$(ruby -e 'print Gem.user_dir')/bin:$PATH"

--- a/install/osx/osx
+++ b/install/osx/osx
@@ -3,7 +3,7 @@
 # osx, runs package manager script, unixlike, and forces zsh
 
 eval $DEVIE_PATH/install/osx/brew
-eval $DEVIE_PATH/install/run_unixlike
+eval $DEVIE_PATH/install/unixlike
 eval $DEVIE_PATH/script/force_zsh
 
 exit 0

--- a/install/unixlike
+++ b/install/unixlike
@@ -22,4 +22,13 @@ else
   printf 'y\ny' | ~/.fzf/install 
 fi
 
+if [ -d "$HOME/.exercism" ]; then
+  echo "exercism already installed."
+else
+  curl -o $HOME/exercism_install https://raw.githubusercontent.com/exercism/cli-www/master/public/install 
+  chmod 705 $HOME/exercism_install
+  eval $HOME/exercism_install $HOME/.exercism
+  rm $HOME/exercism_install
+fi
+
 exit 0


### PR DESCRIPTION
- osx/osx is not evaling the right file
- set correct path for exercism in profile.symlink
- add exercism to all unixlikes

NOTE: for now you will have to run `exercism configure -k $YOURKEY` on your own in order to authenticate.  You only have to run it once, it is similar to devie's `-g` command.
