### PR TITLE
Add a global ansible config meant to improve devenv performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-metadata
 *.egg-info
 Session.vim
+.facts/*

--- a/roles/shell/files/.ansible.cfg
+++ b/roles/shell/files/.ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+callback_whitelist = ansible.posix.profile_tasks, timer
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = ./.facts
+fact_caching_timeout = 86400
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/roles/shell/tasks/ansible.yml
+++ b/roles/shell/tasks/ansible.yml
@@ -1,0 +1,10 @@
+---
+
+- name: ANSIBLE - Symlink ansible.cfg to $HOME
+  file:
+    src: ~/.devenv/roles/shell/files/.ansible.cfg
+    dest: ~/.ansible.cfg
+    state: link
+    force: true
+  tags:
+    - dotfile

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -1,6 +1,7 @@
 - import_tasks: git.yml
 - import_tasks: zsh.yml
 - import_tasks: antigen.yml
+- import_tasks: ansible.yml
 - import_tasks: tree.yml
 - import_tasks: keychain.yml
 - import_tasks: node.yml


### PR DESCRIPTION
- First big advantage is the fact_caching removes a 5 second step that
was running every time.  The only reason I can't just set `gather_facts: no`
is because of the reiance on `ansible_distribution`
- piplining true is supposed to help automatically, we'll see how it
does on CI
- `callback_whitelist` adds timings for individual tasks, as well as the
entire playbook
- SSH multiplexing should be enabled through `ssh_args`

Reference for speeding up ansible:
https://mayeu.me/post/easy-things-you-can-do-to-speed-up-ansible/
https://dzone.com/articles/speed-up-ansible